### PR TITLE
Support customized test target paths in Package.swift

### DIFF
--- a/src/swiftPackage.ts
+++ b/src/swiftPackage.ts
@@ -1,0 +1,180 @@
+// To parse this data:
+//
+//   import { Convert, SwiftPackageManifest } from "./file";
+//
+//   const swiftPackageManifest = SwiftPackageManifestParser.toSwiftPackageManifest(json);
+//
+// These functions will throw an error if the JSON doesn't
+// match the expected interface, even if the JSON is valid.
+
+export interface SwiftPackageManifest {
+    name:         string;
+    targets: SwiftTarget[];
+    toolsVersion: ToolsVersion;
+}
+
+export interface SwiftTarget {
+    name:  string;
+    path?: null | string;
+    type:  string;
+}
+
+export interface ToolsVersion {
+    _version: string;
+}
+
+// Converts JSON strings to/from your types
+// and asserts the results of JSON.parse at runtime
+export class SwiftPackageManifestParser {
+    public static toSwiftPackageManifest(json: string): SwiftPackageManifest {
+        return cast(JSON.parse(json), r("SwiftPackageManifest"));
+    }
+
+    public static swiftPackageManifestToJson(value: SwiftPackageManifest): string {
+        return JSON.stringify(uncast(value, r("SwiftPackageManifest")), null, 2);
+    }
+}
+
+function invalidValue(typ: any, val: any, key: any = ''): never {
+    if (key) {
+        throw Error(`Invalid value for key "${key}". Expected type ${JSON.stringify(typ)} but got ${JSON.stringify(val)}`);
+    }
+    throw Error(`Invalid value ${JSON.stringify(val)} for type ${JSON.stringify(typ)}`, );
+}
+
+function jsonToJSProps(typ: any): any {
+    if (typ.jsonToJS === undefined) {
+        const map: any = {};
+        typ.props.forEach((p: any) => map[p.json] = { key: p.js, typ: p.typ });
+        typ.jsonToJS = map;
+    }
+    return typ.jsonToJS;
+}
+
+function jsToJSONProps(typ: any): any {
+    if (typ.jsToJSON === undefined) {
+        const map: any = {};
+        typ.props.forEach((p: any) => map[p.js] = { key: p.json, typ: p.typ });
+        typ.jsToJSON = map;
+    }
+    return typ.jsToJSON;
+}
+
+function transform(val: any, typ: any, getProps: any, key: any = ''): any {
+    function transformPrimitive(typ: string, val: any): any {
+        if (typeof typ === typeof val) return val;
+        return invalidValue(typ, val, key);
+    }
+
+    function transformUnion(typs: any[], val: any): any {
+        // val must validate against one typ in typs
+        const l = typs.length;
+        for (let i = 0; i < l; i++) {
+            const typ = typs[i];
+            try {
+                return transform(val, typ, getProps);
+            } catch (_) {}
+        }
+        return invalidValue(typs, val);
+    }
+
+    function transformEnum(cases: string[], val: any): any {
+        if (cases.indexOf(val) !== -1) return val;
+        return invalidValue(cases, val);
+    }
+
+    function transformArray(typ: any, val: any): any {
+        // val must be an array with no invalid elements
+        if (!Array.isArray(val)) return invalidValue("array", val);
+        return val.map(el => transform(el, typ, getProps));
+    }
+
+    function transformDate(val: any): any {
+        if (val === null) {
+            return null;
+        }
+        const d = new Date(val);
+        if (isNaN(d.valueOf())) {
+            return invalidValue("Date", val);
+        }
+        return d;
+    }
+
+    function transformObject(props: { [k: string]: any }, additional: any, val: any): any {
+        if (val === null || typeof val !== "object" || Array.isArray(val)) {
+            return invalidValue("object", val);
+        }
+        const result: any = {};
+        Object.getOwnPropertyNames(props).forEach(key => {
+            const prop = props[key];
+            const v = Object.prototype.hasOwnProperty.call(val, key) ? val[key] : undefined;
+            result[prop.key] = transform(v, prop.typ, getProps, prop.key);
+        });
+        Object.getOwnPropertyNames(val).forEach(key => {
+            if (!Object.prototype.hasOwnProperty.call(props, key)) {
+                result[key] = val[key];
+            }
+        });
+        return result;
+    }
+
+    if (typ === "any") return val;
+    if (typ === null) {
+        if (val === null) return val;
+        return invalidValue(typ, val);
+    }
+    if (typ === false) return invalidValue(typ, val);
+    while (typeof typ === "object" && typ.ref !== undefined) {
+        typ = typeMap[typ.ref];
+    }
+    if (Array.isArray(typ)) return transformEnum(typ, val);
+    if (typeof typ === "object") {
+        return typ.hasOwnProperty("unionMembers") ? transformUnion(typ.unionMembers, val)
+            : typ.hasOwnProperty("arrayItems")    ? transformArray(typ.arrayItems, val)
+            : typ.hasOwnProperty("props")         ? transformObject(getProps(typ), typ.additional, val)
+            : invalidValue(typ, val);
+    }
+    // Numbers can be parsed by Date but shouldn't be.
+    if (typ === Date && typeof val !== "number") return transformDate(val);
+    return transformPrimitive(typ, val);
+}
+
+function cast<T>(val: any, typ: any): T {
+    return transform(val, typ, jsonToJSProps);
+}
+
+function uncast<T>(val: T, typ: any): any {
+    return transform(val, typ, jsToJSONProps);
+}
+
+function a(typ: any) {
+    return { arrayItems: typ };
+}
+
+function u(...typs: any[]) {
+    return { unionMembers: typs };
+}
+
+function o(props: any[], additional: any) {
+    return { props, additional };
+}
+
+function r(name: string) {
+    return { ref: name };
+}
+
+const typeMap: any = {
+    "SwiftPackageManifest": o([
+        { json: "name", js: "name", typ: "" },
+        { json: "targets", js: "targets", typ: a(r("SwiftTarget")) },
+        { json: "toolsVersion", js: "toolsVersion", typ: r("ToolsVersion") },
+    ], false),
+    "SwiftTarget": o([
+        { json: "name", js: "name", typ: "" },
+        { json: "path", js: "path", typ: u(undefined, u(null, "")) },
+        { json: "type", js: "type", typ: "" },
+    ], false),
+    "ToolsVersion": o([
+        { json: "_version", js: "_version", typ: "" },
+    ], false),
+};

--- a/src/swiftUtils.ts
+++ b/src/swiftUtils.ts
@@ -262,6 +262,7 @@ export const parseSwiftLoadTestOutput = (debuggable: boolean, handlingData: {cou
     }
 })
 
+
 const parseFirstLine = (line: string): {info: string, file: string, line: number } => {
     const tokens = line.split(':')
     const info = tokens[tokens.length - 1].trim()

--- a/src/swiftUtils.ts
+++ b/src/swiftUtils.ts
@@ -262,7 +262,6 @@ export const parseSwiftLoadTestOutput = (debuggable: boolean, handlingData: {cou
     }
 })
 
-
 const parseFirstLine = (line: string): {info: string, file: string, line: number } => {
     const tokens = line.split(':')
     const info = tokens[tokens.length - 1].trim()


### PR DESCRIPTION
Swift Package Manager allows customized paths for targets, including test targets, in the root manifest file. Taking into account any current customization should enable more complex project layouts to be recognized by the test adapter.

Fetching the package metadata JSON via `swift package dump-package` seems to be the best option to get that information at the moment.

Also has a QoL change that I stumbled into where the test adapter would provide more than one test suite for the same project, and it turned out to be different workspace folders configured in my .code-workspace. Adding a description matching the name of the workspace clears confusions, but I don't know if it's ok to put this here of it another PR would be preferable.